### PR TITLE
Fix __eq__ comparison

### DIFF
--- a/src/iterlist.py
+++ b/src/iterlist.py
@@ -22,19 +22,6 @@ class IterList(object):
         self._iterable = iter(iterable)
         self._list = list()  # type: List[Any]
 
-    @property
-    def _exhausted(self):
-        # type: () -> bool
-        """Private property
-
-        :return: True if the iterable has raised StopIteration
-        """
-        try:
-            self._consume_next()
-            return False
-        except IndexError:
-            return True
-
     def _positive_index(self, index):
         # type: (int) -> int
         """Private

--- a/src/iterlist.py
+++ b/src/iterlist.py
@@ -1,6 +1,7 @@
 """iterlist is a list-like interface for iterables."""
 # pylint: disable=C0103,R0205
 
+from collections import Sequence
 import itertools
 izip = getattr(itertools, "izip", zip)  # python2 compatible iter zip
 try:
@@ -167,9 +168,9 @@ class IterList(object):
 
     def __eq__(self, other):
         # type: (Any) -> bool
+        if not isinstance(other, (IterList, Sequence)):
+            return False
         return (all(a == b for a, b in izip(self, other))
-                and self._exhausted
-                and (isinstance(other, list) or other._exhausted)
                 and len(self) == len(other))
 
     def __ne__(self, other):

--- a/src/iterlist.py
+++ b/src/iterlist.py
@@ -1,7 +1,11 @@
 """iterlist is a list-like interface for iterables."""
 # pylint: disable=C0103,R0205
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    # python 2 compatible
+    from collections import Sequence
 import itertools
 izip = getattr(itertools, "izip", zip)  # python2 compatible iter zip
 try:

--- a/tests/test_iterlist.py
+++ b/tests/test_iterlist.py
@@ -232,6 +232,26 @@ class TestEquality(unittest.TestCase):
         self.assertFalse(a == b)
         self.assertTrue(a != b)
 
+    def test_with_bare_iterable(self):
+        a = iterlist.IterList(range(range_size))
+        b = (v for v in range(range_size))
+        self.assertFalse(a == b)
+        self.assertTrue(a != b)
+        # checking equality shouldn't have collapsed the generator
+        b2 = tuple(b)
+        self.assertTrue(a == b2)
+        self.assertFalse(a != b2)
+
+    def test_with_bare_iterable_different_length(self):
+        a = iterlist.IterList(range(range_size))
+        b = (v for v in range(range_size + 1))
+        self.assertFalse(a == b)
+        self.assertTrue(a != b)
+        # checking equality shouldn't have collapsed the generator
+        b2 = tuple(b)
+        self.assertFalse(a == b2)
+        self.assertTrue(a != b2)
+
 class TestReversed(unittest.TestCase):
     def test_backwards_range(self):
         lazy = iterlist.IterList(range(range_size))

--- a/tests/test_iterlist.py
+++ b/tests/test_iterlist.py
@@ -226,6 +226,12 @@ class TestEquality(unittest.TestCase):
         self.assertTrue(a == b)
         self.assertFalse(a != b)
 
+    def test_with_non_iterable(self):
+        a = iterlist.IterList([])
+        b = 0
+        self.assertFalse(a == b)
+        self.assertTrue(a != b)
+
 class TestReversed(unittest.TestCase):
     def test_backwards_range(self):
         lazy = iterlist.IterList(range(range_size))

--- a/tests/test_iterlist.py
+++ b/tests/test_iterlist.py
@@ -226,6 +226,18 @@ class TestEquality(unittest.TestCase):
         self.assertTrue(a == b)
         self.assertFalse(a != b)
 
+    def test_with_tuple(self):
+        a = iterlist.IterList(range(range_size))
+        b = tuple(range(range_size))
+        self.assertTrue(a == b)
+        self.assertFalse(a != b)
+
+    def test_with_str(self):
+        a = "this is a test"
+        b = iterlist.IterList(a)
+        self.assertTrue(a == b)
+        self.assertFalse(a != b)
+
     def test_with_non_iterable(self):
         a = iterlist.IterList([])
         b = 0


### PR DESCRIPTION
This patch addresses 2 problems discovered while testing:

* Comparison to non-iterable `other` raises a TypeError because `zip`/`izip` can only accept iterable arguments
* Comparison to bare iterators (generators, etc) could possibly succeed, but raise an `AttributeError` because the generator doesn't have an `_exhausted` attribute. Unfortunately, the generator had already been partially consumed at that point with the values thrown away.

To address both issues, `IterList` will only check equality against `collections.Sequence` types or another `IterList`. Because `__len__` actually exhausts an `IterList`, there is no need to explicitly check for the `_exhausted` property, because this is implied by taking `len(self)`. This change will allow IterList to be compared to any sequence type including tuples or strings (char-by-char comparison).

2 test cases have been added to regress these issues.