### PR TITLE
Split immutable interface from mutable interface 

### DIFF
--- a/src/iterlist.py
+++ b/src/iterlist.py
@@ -159,15 +159,8 @@ class CachedIterator(object):
 
         # at this point all elements in both lists are equal
         # in this case, the shorter list is considered less
-        try:
-            self._consume_next()
-        except IndexError:
-            pass
-        try:
-            other._consume_next()
-        except IndexError:
-            pass
-        return len(self._list) < len(other._list)
+        # NOTE: calling len will consume the remainder of both iterables
+        return len(self) < len(other)
 
     def index(self, item, start=0, stop=None):
         # type: (Any, int, Optional[int]) -> int
@@ -224,7 +217,11 @@ class IterTuple(CachedIterator):
     def __lt__(self, other):
         # type: (Union[tuple, IterTuple]) -> bool
         if not isinstance(other, (tuple, IterTuple)):
-            raise NotImplementedError
+            raise TypeError(
+                "'<' not supported between instances of {!r} and {!r}".format(
+                    type(self).__name__, type(other).__name__
+                )
+            )
         return super(IterTuple, self).__lt__(other)
 
 
@@ -244,7 +241,11 @@ class IterList(CachedIterator):
     def __lt__(self, other):
         # type: (Union[list, IterList]) -> bool
         if not isinstance(other, (list, IterList)):
-            raise NotImplementedError
+            raise TypeError(
+                "'<' not supported between instances of {!r} and {!r}".format(
+                    type(self).__name__, type(other).__name__
+                )
+            )
         return super(IterList, self).__lt__(other)
 
     def __setitem__(self, index, value):

--- a/src/iterlist.py
+++ b/src/iterlist.py
@@ -9,7 +9,7 @@ except ImportError:
 import itertools
 izip = getattr(itertools, "izip", zip)  # python2 compatible iter zip
 try:
-    from typing import Any, Callable, Iterable, Iterator, List, Optional, Union, Type
+    from typing import Any, Callable, Iterable, Iterator, List, Optional, Union
 except ImportError:
     pass  # typing is only used for static analysis
 
@@ -132,10 +132,9 @@ class CachedIterator(object):
 
     __nonzero__ = __bool__
 
-    def __repr__(self, cast=tuple):
-        # type: (Type) -> str
-        self._consume_rest()
-        return repr(cast(self._list))
+    def __repr__(self):
+        # type: () -> str
+        return repr(tuple(self))
 
     def __eq__(self, other):
         # type: (Any) -> bool
@@ -204,10 +203,6 @@ class CachedIterator(object):
 class IterTuple(CachedIterator):
     """a tuple-like interface over an iterable that stores iterated values."""
 
-    def __repr__(self):
-        # type: () -> str
-        return super(IterTuple, self).__repr__(cast=tuple)
-
     def __eq__(self, other):
         # type: (Union[tuple, IterTuple]) -> bool
         if not isinstance(other, (tuple, IterTuple)):
@@ -230,7 +225,7 @@ class IterList(CachedIterator):
 
     def __repr__(self):
         # type: () -> str
-        return super(IterList, self).__repr__(cast=list)
+        return repr(list(self))
 
     def __eq__(self, other):
         # type: (Union[list, IterList]) -> bool

--- a/src/iterlist.py
+++ b/src/iterlist.py
@@ -204,13 +204,13 @@ class IterTuple(CachedIterator):
     """a tuple-like interface over an iterable that stores iterated values."""
 
     def __eq__(self, other):
-        # type: (Union[tuple, IterTuple]) -> bool
+        # type: (Any) -> bool
         if not isinstance(other, (tuple, IterTuple)):
             return False
         return super(IterTuple, self).__eq__(other)
 
     def __lt__(self, other):
-        # type: (Union[tuple, IterTuple]) -> bool
+        # type: (Any) -> bool
         if not isinstance(other, (tuple, IterTuple)):
             raise TypeError(
                 "'<' not supported between instances of {!r} and {!r}".format(
@@ -228,13 +228,13 @@ class IterList(CachedIterator):
         return repr(list(self))
 
     def __eq__(self, other):
-        # type: (Union[list, IterList]) -> bool
+        # type: (Any) -> bool
         if not isinstance(other, (list, IterList)):
             return False
         return super(IterList, self).__eq__(other)
 
     def __lt__(self, other):
-        # type: (Union[list, IterList]) -> bool
+        # type: (Any) -> bool
         if not isinstance(other, (list, IterList)):
             raise TypeError(
                 "'<' not supported between instances of {!r} and {!r}".format(

--- a/src/iterlist.py
+++ b/src/iterlist.py
@@ -9,13 +9,13 @@ except ImportError:
 import itertools
 izip = getattr(itertools, "izip", zip)  # python2 compatible iter zip
 try:
-    from typing import Any, Callable, Iterable, Iterator, List, Optional, Union
+    from typing import Any, Callable, Iterable, Iterator, List, Optional, Union, Type
 except ImportError:
     pass  # typing is only used for static analysis
 
 
-class IterList(object):
-    """a list-like interface over an iterable that stores iterated values."""
+class CachedIterator(object):
+    """a tuple-like interface over an iterable that stores iterated values."""
 
     def __init__(self, iterable):
         # type: (Iterable) -> None
@@ -115,16 +115,6 @@ class IterList(object):
         self._consume_up_to(index)
         return self._list[index]
 
-    def __setitem__(self, index, value):
-        # type: (Union[slice, int], Any) -> None
-        self._consume_up_to(index)
-        self._list[index] = value
-
-    def __delitem__(self, index):
-        # type: (Union[slice, int]) -> None
-        self._consume_up_to(index)
-        del self._list[index]
-
     def __len__(self):
         # type: () -> int
         self._consume_rest()
@@ -142,24 +132,14 @@ class IterList(object):
 
     __nonzero__ = __bool__
 
-    def extend(self, rest):
-        # type: (Iterable) -> None
-        """Extend the list with an iterable."""
-        self._iterable = itertools.chain(self._iterable, iter(rest))
-
-    def __iadd__(self, rest):
-        # type: (Iterable) -> IterList
-        self.extend(rest)
-        return self
-
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self, cast=tuple):
+        # type: (Type) -> str
         self._consume_rest()
-        return '[' + ', '.join(repr(item) for item in self._list) + ']'
+        return repr(cast(self._list))
 
     def __eq__(self, other):
         # type: (Any) -> bool
-        if not isinstance(other, (IterList, Sequence)):
+        if not isinstance(other, (CachedIterator, Sequence)):
             return False
         return (all(a == b for a, b in izip(self, other))
                 and len(self) == len(other))
@@ -189,35 +169,6 @@ class IterList(object):
             pass
         return len(self._list) < len(other._list)
 
-    def sort(self, key=None, reverse=False):
-        # type: (Optional[Callable[[Any], bool]], bool) -> None
-        """Stable sort in-place.
-
-        Note: this will consume the entire iterable
-        """
-        self._consume_rest()
-        self._list.sort(key=key, reverse=reverse)
-
-    def reverse(self):
-        # type: () -> None
-        """Reverse in-place.
-
-        Note: this will consume the entire iterable
-        """
-        self._consume_rest()
-        self._list.reverse()
-
-    def pop(self, index=-1):
-        # type: (int) -> Any
-        """Remove and return item at index (default last).
-
-        Raises IndexError if list is empty or index is out of range.
-        """
-        self._consume_up_to(index)
-        item = self._list[index]
-        del self._list[index]
-        return item
-
     def index(self, item, start=0, stop=None):
         # type: (Any, int, Optional[int]) -> int
         """Return first index of item.
@@ -241,6 +192,80 @@ class IterList(object):
         """
         self._consume_rest()
         return self._list.count(item)
+
+    def __iter__(self):
+        # type: () -> Iterator[Any]
+        ix = 0
+        try:
+            # Use a while loop over the list index to ensure all items are
+            # yielded, even if some of the iterable is consumed while __iter__
+            # is stopped
+            while True:
+                self._consume_up_to_index(ix)
+                yield self._list[ix]
+                ix += 1
+        except IndexError:
+            return
+
+
+class IterTuple(CachedIterator):
+    """a tuple-like interface over an iterable that stores iterated values."""
+
+    def __repr__(self):
+        # type: () -> str
+        return super(IterTuple, self).__repr__(cast=tuple)
+
+    def __eq__(self, other):
+        # type: (Union[tuple, IterTuple]) -> bool
+        if not isinstance(other, (tuple, IterTuple)):
+            return False
+        return super(IterTuple, self).__eq__(other)
+
+    def __lt__(self, other):
+        # type: (Union[tuple, IterTuple]) -> bool
+        if not isinstance(other, (tuple, IterTuple)):
+            raise NotImplementedError
+        return super(IterTuple, self).__lt__(other)
+
+
+class IterList(CachedIterator):
+    """a mutable list-like interface over an iterable that stores iterated values."""
+
+    def __repr__(self):
+        # type: () -> str
+        return super(IterList, self).__repr__(cast=list)
+
+    def __eq__(self, other):
+        # type: (Union[list, IterList]) -> bool
+        if not isinstance(other, (list, IterList)):
+            return False
+        return super(IterList, self).__eq__(other)
+
+    def __lt__(self, other):
+        # type: (Union[list, IterList]) -> bool
+        if not isinstance(other, (list, IterList)):
+            raise NotImplementedError
+        return super(IterList, self).__lt__(other)
+
+    def __setitem__(self, index, value):
+        # type: (Union[slice, int], Any) -> None
+        self._consume_up_to(index)
+        self._list[index] = value
+
+    def __delitem__(self, index):
+        # type: (Union[slice, int]) -> None
+        self._consume_up_to(index)
+        del self._list[index]
+
+    def extend(self, rest):
+        # type: (Iterable) -> None
+        """Extend the list with an iterable."""
+        self._iterable = itertools.chain(self._iterable, iter(rest))
+
+    def __iadd__(self, rest):
+        # type: (Iterable) -> IterList
+        self.extend(rest)
+        return self
 
     def remove(self, item):
         # type: (Any) -> None
@@ -276,16 +301,31 @@ class IterList(object):
         del self._list[:]  # self._list.clear() for py3.3+
         self._iterable = iter([])
 
-    def __iter__(self):
-        # type: () -> Iterator[Any]
-        ix = 0
-        try:
-            # Use a while loop over the list index to ensure all items are
-            # yielded, even if some of the iterable is consumed while __iter__
-            # is stopped
-            while True:
-                self._consume_up_to_index(ix)
-                yield self._list[ix]
-                ix += 1
-        except IndexError:
-            return
+    def sort(self, key=None, reverse=False):
+        # type: (Optional[Callable[[Any], bool]], bool) -> None
+        """Stable sort in-place.
+
+        Note: this will consume the entire iterable
+        """
+        self._consume_rest()
+        self._list.sort(key=key, reverse=reverse)
+
+    def reverse(self):
+        # type: () -> None
+        """Reverse in-place.
+
+        Note: this will consume the entire iterable
+        """
+        self._consume_rest()
+        self._list.reverse()
+
+    def pop(self, index=-1):
+        # type: (int) -> Any
+        """Remove and return item at index (default last).
+
+        Raises IndexError if list is empty or index is out of range.
+        """
+        self._consume_up_to(index)
+        item = self._list[index]
+        del self._list[index]
+        return item

--- a/src/iterlist.py
+++ b/src/iterlist.py
@@ -214,8 +214,8 @@ class IterTuple(CachedIterator):
         if not isinstance(other, (tuple, IterTuple)):
             raise TypeError(
                 "'<' not supported between instances of {!r} and {!r}".format(
-                    type(self).__name__, type(other).__name__
-                )
+                    type(self).__name__, type(other).__name__,
+                ),
             )
         return super(IterTuple, self).__lt__(other)
 
@@ -238,8 +238,8 @@ class IterList(CachedIterator):
         if not isinstance(other, (list, IterList)):
             raise TypeError(
                 "'<' not supported between instances of {!r} and {!r}".format(
-                    type(self).__name__, type(other).__name__
-                )
+                    type(self).__name__, type(other).__name__,
+                ),
             )
         return super(IterList, self).__lt__(other)
 

--- a/tests/test_iterlist.py
+++ b/tests/test_iterlist.py
@@ -195,12 +195,22 @@ class TestExtend(unittest.TestCase):
             self.assertEqual(lazy[i], i)
 
 class TestRepr(unittest.TestCase):
-    def test_simple(self):
+    def test_tuple_simple(self):
+        lazy = iterlist.IterTuple(range(3))
+        self.assertEqual(repr(lazy), '(0, 1, 2)')
+
+    def test_list_simple(self):
         lazy = iterlist.IterList(range(3))
         self.assertEqual(repr(lazy), '[0, 1, 2]')
 
 class TestEquality(unittest.TestCase):
-    def test_should_equal(self):
+    def test_should_equal_tuple(self):
+        a = iterlist.IterTuple(range(3))
+        b = iterlist.IterTuple(range(3))
+        self.assertTrue(a == b)
+        self.assertFalse(a != b)
+
+    def test_should_equal_list(self):
         a = iterlist.IterList(range(3))
         b = iterlist.IterList(range(3))
         self.assertTrue(a == b)
@@ -222,21 +232,39 @@ class TestEquality(unittest.TestCase):
 
     def test_with_list(self):
         a = iterlist.IterList(range(range_size))
-        b = list(range(range_size))
-        self.assertTrue(a == b)
-        self.assertFalse(a != b)
+        b = iterlist.IterTuple(range(range_size))
+        c = list(range(range_size))
+        # IterList/IterTuple equality: never equal even with same contents
+        self.assertTrue(a != b)
+        self.assertFalse(a == b)
+        # IterList/list equality
+        self.assertTrue(a == c)
+        self.assertFalse(a != c)
+        # IterTuple/list equality
+        self.assertTrue(b != c)
+        self.assertFalse(b == c)
 
     def test_with_tuple(self):
         a = iterlist.IterList(range(range_size))
-        b = tuple(range(range_size))
-        self.assertTrue(a == b)
-        self.assertFalse(a != b)
+        b = iterlist.IterTuple(range(range_size))
+        c = tuple(range(range_size))
+        # IterList/IterTuple equality: never equal even with same contents
+        self.assertTrue(a != b)
+        self.assertFalse(a == b)
+        # IterList/tuple equality
+        self.assertTrue(a != c)
+        self.assertFalse(a == c)
+        # IterTuple/tuple equality
+        self.assertTrue(b == c)
+        self.assertFalse(b != c)
 
     def test_with_str(self):
         a = "this is a test"
         b = iterlist.IterList(a)
-        self.assertTrue(a == b)
-        self.assertFalse(a != b)
+        self.assertTrue(a != b)
+        self.assertFalse(a == b)
+        self.assertTrue(list(a) == b)
+        self.assertFalse(list(a) != b)
 
     def test_with_non_iterable(self):
         a = iterlist.IterList([])
@@ -250,7 +278,7 @@ class TestEquality(unittest.TestCase):
         self.assertFalse(a == b)
         self.assertTrue(a != b)
         # checking equality shouldn't have collapsed the generator
-        b2 = tuple(b)
+        b2 = list(b)
         self.assertTrue(a == b2)
         self.assertFalse(a != b2)
 
@@ -260,7 +288,7 @@ class TestEquality(unittest.TestCase):
         self.assertFalse(a == b)
         self.assertTrue(a != b)
         # checking equality shouldn't have collapsed the generator
-        b2 = tuple(b)
+        b2 = list(b)
         self.assertFalse(a == b2)
         self.assertTrue(a != b2)
 

--- a/tests/test_iterlist.py
+++ b/tests/test_iterlist.py
@@ -268,9 +268,15 @@ class TestEquality(unittest.TestCase):
 
     def test_with_non_iterable(self):
         a = iterlist.IterList([])
-        b = 0
-        self.assertFalse(a == b)
-        self.assertTrue(a != b)
+        b = iterlist.IterTuple([])
+        c = iterlist.CachedIterator([])
+        d = 0
+        self.assertFalse(a == d)
+        self.assertTrue(a != d)
+        self.assertFalse(b == d)
+        self.assertTrue(b != d)
+        self.assertFalse(c == d)
+        self.assertTrue(c != d)
 
     def test_with_bare_iterable(self):
         a = iterlist.IterList(range(range_size))
@@ -419,6 +425,57 @@ class TestLessThan(unittest.TestCase):
         b = iterlist.IterList([2, -1])
         self.assertTrue(a < b)
         self.assertFalse(b < a)
+
+    def test_with_list(self):
+        a = iterlist.IterList(range(range_size))
+        b = iterlist.IterTuple(range(range_size))
+        c = list(range(-1, range_size-1))
+        d = list(range(1, range_size+1))
+        e = list(range(range_size))
+        self.assertTrue(a < d)
+        self.assertFalse(a < c)
+        self.assertFalse(a < e)
+        # cannot compare IterList and tuple
+        with self.assertRaises(TypeError):
+            self.assertTrue(b < d)
+        with self.assertRaises(TypeError):
+            self.assertFalse(b < c)
+        with self.assertRaises(TypeError):
+            self.assertFalse(b < e)
+        try:
+            self.assertFalse(d < a)
+            # XXX: doesn't actually do less than, always False
+            self.assertFalse(c < a)
+            self.assertFalse(e < a)
+        except TypeError:
+            # cannot compare list and IterList on py3
+            pass
+
+    def test_with_tuple(self):
+        a = iterlist.IterTuple(range(range_size))
+        b = iterlist.IterList(range(range_size))
+        c = tuple(range(-1, range_size-1))
+        d = tuple(range(1, range_size+1))
+        e = tuple(range(range_size))
+        self.assertTrue(a < d)
+        self.assertFalse(a < c)
+        self.assertFalse(a < e)
+        # cannot compare IterList and tuple
+        with self.assertRaises(TypeError):
+            self.assertTrue(b < d)
+        with self.assertRaises(TypeError):
+            self.assertFalse(b < c)
+        with self.assertRaises(TypeError):
+            self.assertFalse(b < e)
+        try:
+            self.assertFalse(d < a)
+            # XXX: doesn't actually do less than, always False
+            self.assertFalse(c < a)
+            self.assertFalse(e < a)
+        except TypeError:
+            # cannot compare tuple and IterTuple on py3
+            pass
+
 
 
 class TestIter(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands =
 
 [flake8]
 extend-ignore = D400,D105
+max-line-length = 92
 
 
 [gh-actions]


### PR DESCRIPTION
New base class 'CachedIterator' is the basic interface for consuming an iterable as it is needed. The underlying cache is a list, but it is not exposed in this interface and the object actually behaves a lot like a tuple. The main difference is that a CachedIterator will perform item-by-item equality and comparison checking for any type of sequence.

IterTuple extends CachedIterator and can be used for tuple-like semantics: it will only perform equlity/comparison checking against tuple and IterTuple instances.

IterList extends CachedIterator and retains the existing interface for mutable operations, and additionally equality and comparisons are restricted to list and IterList instances.

Additional clean up for __lt__ comparison operator.