### PR TITLE
Optionally take a lock when stepping the iterator

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 # Regexes for lines to exclude from consideration
 exclude_lines =
     except ImportError:
+    pragma: no cover

--- a/tests/test_iterlist.py
+++ b/tests/test_iterlist.py
@@ -507,14 +507,14 @@ class TestIter(unittest.TestCase):
 
 
 class TestConcurrentAccess(unittest.TestCase):
-    def gen_test_multiple_iterators(self, iterlist_clz=iterlist.ThreadsafeIterTuple, delay=0.005, n_threads=5):
+    def gen_test_multiple_iterators(self, iterlist_clz, delay=0.005, n_threads=5):
         orig = list(range(range_size))
         delay_generator = (ix for ix in orig if time.sleep(delay) is None)
         lazy = iterlist_clz(delay_generator)
         with concurrent.futures.ThreadPoolExecutor(n_threads) as tp:
             future_results = [tp.submit(lambda: [x for x in lazy]) for _ in
                               range(n_threads)]
-            results = [f.result() for f in future_results]
+            results = [f.result(timeout=1) for f in future_results]
         for r in results:
             self.assertEqual(r, orig)
 
@@ -529,6 +529,29 @@ class TestConcurrentAccess(unittest.TestCase):
             self.gen_test_multiple_iterators(iterlist_clz=iterlist.IterTuple)
         with self.assertRaises(iterlist.ConcurrentGeneratorAccess) as cga:
             self.gen_test_multiple_iterators(iterlist_clz=iterlist.IterList)
+
+    def gen_test_concurrent_length(self, iterlist_clz, delay=0.005, n_threads=5):
+        orig = list(range(range_size))
+        delay_generator = (ix for ix in orig if time.sleep(delay) is None)
+        lazy = iterlist_clz(delay_generator)
+        with concurrent.futures.ThreadPoolExecutor(n_threads) as tp:
+            future_results = [tp.submit(lambda: len(lazy)) for _ in
+                              range(n_threads)]
+            results = [f.result(timeout=1) for f in future_results]
+        for r in results:
+            self.assertEqual(r, len(orig))
+
+    def test_concurrent_length_itertuple(self):
+        self.gen_test_concurrent_length(iterlist_clz=iterlist.ThreadsafeIterTuple)
+
+    def test_concurrent_length_iterlist(self):
+        self.gen_test_concurrent_length(iterlist_clz=iterlist.ThreadsafeIterList)
+
+    def test_concurrent_length_no_lock(self):
+        with self.assertRaises(iterlist.ConcurrentGeneratorAccess) as cga:
+            self.gen_test_concurrent_length(iterlist_clz=iterlist.IterTuple)
+        with self.assertRaises(iterlist.ConcurrentGeneratorAccess) as cga:
+            self.gen_test_concurrent_length(iterlist_clz=iterlist.IterList)
 
 
 if __name__ == '__main__':

--- a/tests/test_iterlist.py
+++ b/tests/test_iterlist.py
@@ -1,5 +1,8 @@
+import concurrent.futures
 import itertools
 import math
+import threading
+import time
 import unittest
 
 import iterlist
@@ -501,6 +504,31 @@ class TestIter(unittest.TestCase):
                 lazy[5]
                 self.assertEqual(len(lazy._list), 6)
             self.assertEqual(v, orig[ix])
+
+
+class TestConcurrentAccess(unittest.TestCase):
+    def gen_test_multiple_iterators(self, iterlist_clz=iterlist.ThreadsafeIterTuple, delay=0.005, n_threads=5):
+        orig = list(range(range_size))
+        delay_generator = (ix for ix in orig if time.sleep(delay) is None)
+        lazy = iterlist_clz(delay_generator)
+        with concurrent.futures.ThreadPoolExecutor(n_threads) as tp:
+            future_results = [tp.submit(lambda: [x for x in lazy]) for _ in
+                              range(n_threads)]
+            results = [f.result() for f in future_results]
+        for r in results:
+            self.assertEqual(r, orig)
+
+    def test_multiple_iterators_itertuple(self):
+        self.gen_test_multiple_iterators(iterlist_clz=iterlist.ThreadsafeIterTuple)
+
+    def test_multiple_iterators_iterlist(self):
+        self.gen_test_multiple_iterators(iterlist_clz=iterlist.ThreadsafeIterList)
+
+    def test_multiple_iterators_no_lock(self):
+        with self.assertRaises(iterlist.ConcurrentGeneratorAccess) as cga:
+            self.gen_test_multiple_iterators(iterlist_clz=iterlist.IterTuple)
+        with self.assertRaises(iterlist.ConcurrentGeneratorAccess) as cga:
+            self.gen_test_multiple_iterators(iterlist_clz=iterlist.IterList)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,12 @@ deps =
 commands =
     pytest --cov iterlist --cov-fail-under 100 --cov-report term-missing {posargs:tests}
 
+[testenv:py27]
+deps =
+    pytest ~= 4.6.0
+    pytest-cov ~= 2.8.0
+    futures
+
 [testenv:static]
 basepython = python3.7
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ envlist =
 
 [testenv]
 deps =
-    pytest ~= 4.6.0
-    pytest-cov ~= 2.8.0
+    pytest
+    pytest-cov
 commands =
     pytest --cov iterlist --cov-fail-under 100 --cov-report term-missing {posargs:tests}
 


### PR DESCRIPTION
Avoid concurrent generator access that may arise when multiple threads access a `CachedIterator`